### PR TITLE
Split routes into Flask Blueprints

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -27,8 +27,15 @@ app.config["SW_VIZ_TOKEN"] = os.environ.get("SW_VIZ_TOKEN", "")
 
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 
-# Import routes after app creation to avoid circular imports
-from app.routes import api_software, api_documents, coar_inbox, api_status
+from app.routes.api_documents import api_documents_bp
+from app.routes.api_software import api_software_bp
+from app.routes.api_status import api_status_bp
+from app.routes.coar_inbox import coar_inbox_bp
+
+app.register_blueprint(api_documents_bp)
+app.register_blueprint(api_software_bp)
+app.register_blueprint(api_status_bp)
+app.register_blueprint(coar_inbox_bp)
 
 db_manager = init_db(app)
 

--- a/app/routes/api_documents.py
+++ b/app/routes/api_documents.py
@@ -1,112 +1,103 @@
 import logging
-from app.app import app
-from flask import jsonify, request
+
+from flask import Blueprint, jsonify, request
 
 from app.auth import require_api_key
 from app.utils.db import get_db
-from app.utils.notification_handler import send_notifications_to_swh, send_notifications_to_hal, \
-    get_software_notifications
+from app.utils.notification_handler import (
+    get_software_notifications,
+    send_notifications_to_hal,
+    send_notifications_to_swh,
+)
 
 logger = logging.getLogger(__name__)
 
-@app.route('/api/documents', methods=['GET'])
+api_documents_bp = Blueprint("api_documents", __name__)
+
+
+@api_documents_bp.route("/api/documents", methods=["GET"])
 def documents_status():
     try:
         db_manager = get_db()
         total_count = db_manager.get_collection_count("documents")
-        status_info = {
+        return jsonify({
             "collection_name": "documents",
             "total_documents": total_count,
-        }
-        return jsonify(status_info)
+        })
     except Exception as e:
         logger.error(f"Failed to get documents status: {e}")
         return jsonify({"error": "Failed to retrieve documents status"}), 500
 
-@app.route('/api/document/<id>', methods=['GET'])
+
+@api_documents_bp.route("/api/document/<id>", methods=["GET"])
 def document_from_id(id):
     try:
         db_manager = get_db()
         doc = db_manager.get_document_by_id(id)
         if doc:
             return jsonify(doc)
-        else:
-            return jsonify({"error": "Document not found"}), 404
+        return jsonify({"error": "Document not found"}), 404
     except Exception as e:
         logger.error(f"Failed to get document {id}: {e}")
         return jsonify({"error": "Failed to retrieve document"}), 500
 
-@app.route('/api/document/<id>', methods=['DELETE'])
+
+@api_documents_bp.route("/api/document/<id>", methods=["DELETE"])
 @require_api_key
 def delete_document(id):
     """
     Delete a document and all its associated software mentions.
-
-    Args:
-        id: HAL document identifier (file_hal_id)
-
-    Returns:
-        JSON response with deletion status
     """
     try:
         db_manager = get_db()
 
-        # First check if document exists
-        doc_result = db_manager.get_document_by_id(id)
-        if not doc_result:
+        if not db_manager.get_document_by_id(id):
             return jsonify({"error": "Document not found"}), 404
 
-        # Delete the document using the database manager method
         deletion_result = db_manager.delete_document_by_id(id)
-
         if deletion_result:
             return jsonify({
                 "status": "deleted",
                 "document_id": id,
-                "software_deleted": deletion_result.get("software_deleted", 0)
+                "software_deleted": deletion_result.get("software_deleted", 0),
             })
-        else:
-            return jsonify({"error": "Failed to delete document"}), 500
-
+        return jsonify({"error": "Failed to delete document"}), 500
     except Exception as e:
         logger.error(f"Failed to delete document {id}: {e}")
         return jsonify({"error": "Failed to delete document"}), 500
 
-@app.route('/api/document/<id_document>/software', methods=['GET'])
+
+@api_documents_bp.route("/api/document/<id_document>/software", methods=["GET"])
 def document_software_all_from_id(id_document):
     try:
         db_manager = get_db()
-        result = db_manager.get_document_software(id_document)
-        return jsonify(result)
+        return jsonify(db_manager.get_document_software(id_document))
     except Exception as e:
         logger.error(f"Failed to get software for document {id_document}: {e}")
         return jsonify({"error": "Failed to retrieve document software"}), 500
 
-@app.route('/api/document/<id_document>/software/<id_software>', methods=['GET'])
+
+@api_documents_bp.route(
+    "/api/document/<id_document>/software/<id_software>", methods=["GET"]
+)
 def document_software_from_id(id_document, id_software):
     try:
         db_manager = get_db()
-        result = db_manager.get_document_software(id_document, id_software)
-        return jsonify(result)
+        return jsonify(db_manager.get_document_software(id_document, id_software))
     except Exception as e:
-        logger.error(f"Failed to get software {id_software} for document {id_document}: {e}")
+        logger.error(
+            f"Failed to get software {id_software} for document {id_document}: {e}"
+        )
         return jsonify({"error": "Failed to retrieve document software"}), 500
 
 
-@app.route("/api/document", methods=["POST"])
+@api_documents_bp.route("/api/document", methods=["POST"])
 @require_api_key
 def insert_new_document():
     """
-    Expects a JSON file of a document uploaded as form-data with key 'file' and a mandatory document_id parameter.
-    The document_id will be used as the HAL identifier instead of extracting from filename.
-
-    Form-data fields:
-    - file: JSON file containing software metadata (required)
-    - document_id: HAL identifier for the document (required)
-
-    Returns meaningful HTTP status codes.
+    Expects a JSON file uploaded as form-data with key 'file' and a mandatory document_id
+    field used as the HAL identifier for the document.
     """
-    # Validate required fields
     if "file" not in request.files:
         return jsonify({"error": "No file provided"}), 400
 
@@ -118,68 +109,51 @@ def insert_new_document():
 
     try:
         db_manager = get_db()
-        # Override the filename with the provided document_id for HAL identification
-        original_filename = file.filename
-        inserted = db_manager.insert_document_as_json(document_id, file)  # returns True if inserted, False if duplicate
-
-
+        inserted = db_manager.insert_document_as_json(document_id, file)
     except Exception as e:
         logger.error(f"File insertion failed: {e}")
         return jsonify({"error": f"Insertion failed: {str(e)}"}), 500
 
-    if inserted:
-        notifications = get_software_notifications(document_id)
-
-        notification_results = {}
-        try:
-            hal_result = send_notifications_to_hal(document_id, notifications)
-            notification_results["hal"] = {
-                "sent": hal_result["success_count"],
-                "failed": hal_result["failure_count"]
-            }
-        except Exception as e:
-            logger.error(f"HAL notification failed for {document_id}: {e}")
-            notification_results["hal"] = {
-                "sent": 0,
-                "failed": len(notifications) if notifications else 0,
-                "error": str(e)
-            }
-
-        try:
-            swh_result = send_notifications_to_swh(document_id, notifications)
-            notification_results["swh"] = {
-                "sent": swh_result["success_count"],
-                "failed": swh_result["failure_count"]
-            }
-        except Exception as e:
-            logger.error(f"SWH notification failed for {document_id}: {e}")
-            notification_results["swh"] = {
-                "sent": 0,
-                "failed": len(notifications) if notifications else 0,
-                "error": str(e)
-            }
-
-        total_sent = sum(result.get("sent", 0) for result in notification_results.values())
-        total_failed = sum(result.get("failed", 0) for result in notification_results.values())
-
-        return jsonify({
-            "status": "inserted",
-            "file": original_filename,
-            "document_id": document_id,
-            "notifications": {
-                "summary": {
-                    "total_sent": total_sent,
-                    "total_failed": total_failed,
-                    "total_attempts": total_sent + total_failed
-                },
-                "by_provider": notification_results
-            }
-        }), 201
-    else:
-        # Document already exists
+    if not inserted:
         return jsonify({
             "status": "exists",
             "message": "Document already exists in the database",
             "document_id": document_id,
-            "file": original_filename
         }), 409
+
+    notifications = get_software_notifications(document_id)
+    notification_results = {}
+
+    for provider, sender in (
+        ("hal", send_notifications_to_hal),
+        ("swh", send_notifications_to_swh),
+    ):
+        try:
+            result = sender(document_id, notifications)
+            notification_results[provider] = {
+                "sent": result["success_count"],
+                "failed": result["failure_count"],
+            }
+        except Exception as e:
+            logger.error(f"{provider.upper()} notification failed for {document_id}: {e}")
+            notification_results[provider] = {
+                "sent": 0,
+                "failed": len(notifications) if notifications else 0,
+                "error": str(e),
+            }
+
+    total_sent = sum(r.get("sent", 0) for r in notification_results.values())
+    total_failed = sum(r.get("failed", 0) for r in notification_results.values())
+
+    return jsonify({
+        "status": "inserted",
+        "document_id": document_id,
+        "notifications": {
+            "summary": {
+                "total_sent": total_sent,
+                "total_failed": total_failed,
+                "total_attempts": total_sent + total_failed,
+            },
+            "by_provider": notification_results,
+        },
+    }), 201

--- a/app/routes/api_software.py
+++ b/app/routes/api_software.py
@@ -1,66 +1,60 @@
 import logging
-from app.app import app
-from flask import request, jsonify
-from app.utils.db import get_db
-from app.utils.blacklist_manager import blacklist_manager
+
+from flask import Blueprint, Response, jsonify, request
+
 from app.auth import require_api_key
+from app.utils.blacklist_manager import blacklist_manager
+from app.utils.db import get_db
 
 logger = logging.getLogger(__name__)
 
-@app.route('/api/software', methods=['GET'])
+api_software_bp = Blueprint("api_software", __name__)
+
+
+@api_software_bp.route("/api/software", methods=["GET"])
 def software_status():
     try:
         db_manager = get_db()
         total_count = db_manager.get_collection_count("software")
-        status_info = {
+        return jsonify({
             "collection_name": "software",
             "total_documents": total_count,
-        }
-        return jsonify(status_info)
+        })
     except Exception as e:
         logger.error(f"Failed to get software status: {e}")
         return jsonify({"error": "Failed to retrieve software status"}), 500
 
-@app.route('/api/software/name/<name>', methods=['GET'])
-def software_from_id(name):
+
+@api_software_bp.route("/api/software/name/<name>", methods=["GET"])
+def software_from_name(name):
     try:
         db_manager = get_db()
-        result = db_manager.get_software_by_normalized_name(name)
-        return jsonify(result)
+        return jsonify(db_manager.get_software_by_normalized_name(name))
     except Exception as e:
         logger.error(f"Failed to get software by {name}: {e}")
         return jsonify({"error": "Failed to retrieve software"}), 500
 
-@app.route('/api/software/<id_mention>', methods=['GET'])
+
+@api_software_bp.route("/api/software/<id_mention>", methods=["GET"])
 def software_mention_from_id(id_mention):
     try:
         db_manager = get_db()
         doc = db_manager.get_document_by_key("software", id_mention)
         if doc:
             return jsonify(doc)
-        else:
-            return jsonify({"error": "Document not found"}), 404
+        return jsonify({"error": "Software mention not found"}), 404
     except Exception as e:
         logger.error(f"Failed to get software mention {id_mention}: {e}")
         return jsonify({"error": "Failed to retrieve software mention"}), 500
 
 
 # Blacklist management endpoints
-@app.route('/api/blacklist', methods=['GET'])
+
+@api_software_bp.route("/api/blacklist", methods=["GET"])
 def get_blacklist():
-    """
-    Get the current blacklist of software terms.
-
-    Query Parameters:
-    - search: Search terms (optional)
-    - limit: Maximum number of results (default: 50)
-
-    Returns:
-        JSON with blacklist data
-    """
     try:
-        search_query = request.args.get('search', '').strip()
-        limit = int(request.args.get('limit', 50))
+        search_query = request.args.get("search", "").strip()
+        limit = int(request.args.get("limit", 50))
 
         stats = blacklist_manager.get_blacklist_stats()
 
@@ -71,55 +65,38 @@ def get_blacklist():
                 "terms": terms,
                 "search_query": search_query,
                 "limit": limit,
-                "total_matches": len(terms)
+                "total_matches": len(terms),
             })
-        else:
-            # Return all terms if no search
-            all_terms = sorted(blacklist_manager.get_blacklist())
-            return jsonify({
-                "stats": stats,
-                "terms": all_terms,
-                "total_count": len(all_terms)
-            })
+
+        all_terms = sorted(blacklist_manager.get_blacklist())
+        return jsonify({
+            "stats": stats,
+            "terms": all_terms,
+            "total_count": len(all_terms),
+        })
     except Exception as e:
         logger.error(f"Failed to get blacklist: {e}")
         return jsonify({"error": "Failed to retrieve blacklist"}), 500
 
 
-@app.route('/api/blacklist/stats', methods=['GET'])
+@api_software_bp.route("/api/blacklist/stats", methods=["GET"])
 def get_blacklist_stats():
-    """
-    Get statistics about the blacklist.
-
-    Returns:
-        JSON with blacklist statistics
-    """
     try:
-        stats = blacklist_manager.get_blacklist_stats()
-        return jsonify(stats)
+        return jsonify(blacklist_manager.get_blacklist_stats())
     except Exception as e:
         logger.error(f"Failed to get blacklist stats: {e}")
         return jsonify({"error": "Failed to retrieve blacklist statistics"}), 500
 
 
-@app.route('/api/blacklist', methods=['POST'])
+@api_software_bp.route("/api/blacklist", methods=["POST"])
 @require_api_key
 def add_to_blacklist():
-    """
-    Add a term to the blacklist.
-
-    JSON Body:
-    - term: term to add to blacklist (required)
-
-    Returns:
-        JSON with operation result
-    """
     try:
         data = request.get_json()
-        if not data or 'term' not in data:
+        if not data or "term" not in data:
             return jsonify({"error": "term is required in request body"}), 400
 
-        term = data['term'].strip()
+        term = data["term"].strip()
         if not term:
             return jsonify({"error": "term cannot be empty"}), 400
 
@@ -127,134 +104,93 @@ def add_to_blacklist():
             return jsonify({
                 "success": True,
                 "message": f"Term '{term}' added to blacklist",
-                "term": term
+                "term": term,
             }), 201
-        else:
-            return jsonify({
-                "success": False,
-                "message": f"Term '{term}' already exists in blacklist",
-                "term": term
-            }), 409
+        return jsonify({
+            "success": False,
+            "message": f"Term '{term}' already exists in blacklist",
+            "term": term,
+        }), 409
     except Exception as e:
         logger.error(f"Failed to add term to blacklist: {e}")
         return jsonify({"error": "Failed to add term to blacklist"}), 500
 
 
-@app.route('/api/blacklist/<term>', methods=['DELETE'])
+@api_software_bp.route("/api/blacklist/<term>", methods=["DELETE"])
 @require_api_key
 def remove_from_blacklist(term):
-    """
-    Remove a term from the blacklist.
-
-    Args:
-        term: term to remove from blacklist
-
-    Returns:
-        JSON with operation result
-    """
     try:
         if blacklist_manager.remove_from_blacklist(term):
             return jsonify({
                 "success": True,
                 "message": f"Term '{term}' removed from blacklist",
-                "term": term
+                "term": term,
             })
-        else:
-            return jsonify({
-                "success": False,
-                "message": f"Term '{term}' not found in blacklist",
-                "term": term
-            }), 404
+        return jsonify({
+            "success": False,
+            "message": f"Term '{term}' not found in blacklist",
+            "term": term,
+        }), 404
     except Exception as e:
         logger.error(f"Failed to remove term from blacklist: {e}")
         return jsonify({"error": "Failed to remove term from blacklist"}), 500
 
 
-@app.route('/api/blacklist/reload', methods=['POST'])
+@api_software_bp.route("/api/blacklist/reload", methods=["POST"])
 @require_api_key
 def reload_blacklist():
-    """
-    Reload the blacklist from file.
-
-    Returns:
-        JSON with reload result
-    """
     try:
         term_count = blacklist_manager.reload_blacklist()
         return jsonify({
             "success": True,
-            "message": f"Blacklist reloaded successfully",
-            "total_terms": term_count
+            "message": "Blacklist reloaded successfully",
+            "total_terms": term_count,
         })
     except Exception as e:
         logger.error(f"Failed to reload blacklist: {e}")
         return jsonify({"error": "Failed to reload blacklist"}), 500
 
 
-@app.route('/api/blacklist/export', methods=['GET'])
+@api_software_bp.route("/api/blacklist/export", methods=["GET"])
 def export_blacklist():
-    """
-    Export the blacklist as CSV.
-
-    Returns:
-        CSV file download
-    """
     try:
         csv_content = blacklist_manager.export_blacklist()
-
-        from flask import Response
-        response = Response(
+        return Response(
             csv_content,
-            mimetype='text/csv',
-            headers={
-                'Content-Disposition': 'attachment; filename=blacklist.csv'
-            }
+            mimetype="text/csv",
+            headers={"Content-Disposition": "attachment; filename=blacklist.csv"},
         )
-        return response
     except Exception as e:
         logger.error(f"Failed to export blacklist: {e}")
         return jsonify({"error": "Failed to export blacklist"}), 500
 
 
-@app.route('/api/blacklist/import', methods=['POST'])
+@api_software_bp.route("/api/blacklist/import", methods=["POST"])
 @require_api_key
 def import_blacklist():
-    """
-    Import blacklist from CSV file upload.
-
-    Form Data:
-    - file: CSV file to import (required)
-    - overwrite: Whether to overwrite existing blacklist (default: false)
-
-    Returns:
-        JSON with import result
-    """
     try:
-        if 'file' not in request.files:
+        if "file" not in request.files:
             return jsonify({"error": "No file provided"}), 400
 
-        file = request.files['file']
-        if not file.filename.endswith('.csv'):
+        file = request.files["file"]
+        if not file.filename.endswith(".csv"):
             return jsonify({"error": "File must be a CSV file"}), 400
 
-        overwrite = request.form.get('overwrite', 'false').lower() in ['true', '1', 'yes']
-
-        csv_content = file.read().decode('utf-8')
+        overwrite = request.form.get("overwrite", "false").lower() in ["true", "1", "yes"]
+        csv_content = file.read().decode("utf-8")
         result = blacklist_manager.import_blacklist_from_csv(csv_content, overwrite)
 
-        if result['success']:
+        if result["success"]:
             return jsonify({
                 "success": True,
                 "message": f"Successfully imported {result['imported_terms']} terms",
-                "total_terms": result['total_terms'],
-                "overwrite": result['overwrite']
+                "total_terms": result["total_terms"],
+                "overwrite": result["overwrite"],
             })
-        else:
-            return jsonify({
-                "success": False,
-                "error": result.get('error', 'Import failed')
-            }), 400
-
+        return jsonify({
+            "success": False,
+            "error": result.get("error", "Import failed"),
+        }), 400
     except Exception as e:
         logger.error(f"Failed to import blacklist: {e}")
         return jsonify({"error": "Failed to import blacklist"}), 500

--- a/app/routes/api_status.py
+++ b/app/routes/api_status.py
@@ -1,46 +1,44 @@
 import logging
-from flask import jsonify
-from app.app import app
-from app.utils.db import get_db
+
+from flask import Blueprint, jsonify
+
 from app.auth import require_api_key
+from app.utils.db import get_db
 
 logger = logging.getLogger(__name__)
 
-@app.route("/status", methods=["GET"])
+api_status_bp = Blueprint("api_status", __name__)
+
+
+@api_status_bp.route("/status", methods=["GET"])
 @require_api_key
 def can_upload():
     """
-    Simple route to check if the API key is valid
-    and if the database is reachable.
+    Check API-key validity and database reachability, and report which
+    essential collections exist.
     """
     try:
         db_manager = get_db()
 
-        # Check if main collections exist
         collections = ["documents", "software", "edge_doc_to_software"]
         existing = {}
-
         for collection in collections:
             try:
-                collection_obj = db_manager.get_collection(collection)
-                existing[collection] = collection_obj is not None
+                existing[collection] = db_manager.get_collection(collection) is not None
             except Exception as e:
                 logger.warning(f"Failed to check collection {collection}: {e}")
                 existing[collection] = False
 
-        # If any essential collection is missing, we can't upload
         can_upload = all(existing.values())
-
         return jsonify({
             "status": "ok" if can_upload else "error",
             "can_upload": can_upload,
-            "collections": existing
+            "collections": existing,
         })
-
     except Exception as e:
         logger.error(f"Status check failed: {e}")
         return jsonify({
             "status": "error",
             "message": str(e),
-            "can_upload": False
+            "can_upload": False,
         }), 500

--- a/app/routes/coar_inbox.py
+++ b/app/routes/coar_inbox.py
@@ -1,16 +1,17 @@
 import logging
 
-from flask import request, jsonify, render_template
+from flask import Blueprint, request, jsonify, render_template
 
-from app.app import app
 from app.utils.notification_handler import accept_notification, reject_notification, \
     send_validation_to_viz
 
 logger = logging.getLogger(__name__)
 
+coar_inbox_bp = Blueprint("coar_inbox", __name__)
+
 received_notifications = []
 
-@app.route("/inbox", methods=["POST"])
+@coar_inbox_bp.route("/inbox", methods=["POST"])
 def receive_notification():
     """
     COAR Notify inbox.
@@ -58,7 +59,7 @@ def receive_notification():
         "actor": getattr(notification['actor'], "id", None)
     }), 202
 
-@app.route("/inbox", methods=["GET"])
+@coar_inbox_bp.route("/inbox", methods=["GET"])
 def inbox_description():
     """
     COAR Notify inbox description.
@@ -167,7 +168,7 @@ def inbox_description():
     })
 
 
-@app.route("/notifications", methods=["GET"])
+@coar_inbox_bp.route("/notifications", methods=["GET"])
 def show_notifications():
     """
     Display all received notifications on a web page.

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -131,10 +131,10 @@
     <div class="links">
       <h2>Endpoints</h2>
       <a href="{{ url_for('health') }}">Health Check (JSON)</a>
-      <a href="{{ url_for('software_status') }}">Software API Status</a>
-      <a href="{{ url_for('documents_status') }}">Documents API Status</a>
+      <a href="{{ url_for('api_software.software_status') }}">Software API Status</a>
+      <a href="{{ url_for('api_documents.documents_status') }}">Documents API Status</a>
       {% if status == 'up' %}
-        <a href="{{ url_for('show_notifications') }}">View Notifications</a>
+        <a href="{{ url_for('coar_inbox.show_notifications') }}">View Notifications</a>
       {% endif %}
     </div>
   </main>

--- a/app/utils/blacklist_manager.py
+++ b/app/utils/blacklist_manager.py
@@ -2,8 +2,6 @@ import csv
 import logging
 import os
 from typing import List, Set
-# from flask import jsonify, request  # Removed unused imports
-from app.auth import require_api_key
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Convert the four route modules to Blueprints registered in app.py, removing the `from app.app import app` import that created a circular dependency. 