### PR TITLE
Persist received COAR notifications in ArangoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ see [Database Schema Documentation](docs/database.md).
 | GET                      | `/inbox`                               | No            | Get inbox API documentation              |
 | POST                     | `/inbox`                               | No            | Receive COAR notification                |
 | GET                      | `/notifications`                       | No            | View received notifications (HTML)       |
+| GET                      | `/api/notifications`                   | Yes           | List received notifications (JSON)       |
+| GET                      | `/api/notifications/<key>`             | Yes           | Get a received notification by key (JSON)|
 
 ### Authentication
 
@@ -433,12 +435,34 @@ The COAR Notify inbox handles bidirectional communication for software mention v
     - Supported types: `Accept`, `Reject`
     - Returns 202 with notification processing summary
     - Automatically updates verification status in database
+    - **Every** received notification is persisted to the `received_notifications`
+      collection (with a `received_at` timestamp and a classified `origin` of
+      `swh`, `hal`, or `unknown`), including those that are ignored.
+    - Notifications originating from Software Heritage are stored but **not
+      dispatched** (returned with `"status": "ignored"`), to avoid notification
+      loops.
 
 #### View Received Notifications
 
 - **GET `/notifications`**
     - Renders an HTML page displaying all received notifications
     - Useful for debugging and inspection during development
+
+#### List Received Notifications (JSON)
+
+- **GET `/api/notifications`** — requires `x-api-key`
+    - Returns recent received notifications as JSON, newest first
+    - Query params:
+        - `limit` — max records to return (1–1000, default 100)
+        - `origin` — optional filter, `swh` or `hal` (any other value → 400)
+    - Response: `{ "count": <n>, "origin": <filter|null>, "notifications": [ ... ] }`
+    - Each record: `{ "_key", "received_at", "origin", "payload": { ...verbatim notification... } }`
+
+#### Get a Received Notification by Key (JSON)
+
+- **GET `/api/notifications/<key>`** — requires `x-api-key`
+    - `<key>` is the `_key` returned by the list endpoint
+    - Returns the single record, or 404 if not found
 
 Examples:
 
@@ -472,6 +496,18 @@ curl -s -X POST \
 
 # View notifications in browser
 # http://localhost:5000/notifications
+
+# List received notifications as JSON (requires API key)
+curl -s -H "x-api-key: $API_TOKEN" \
+  "http://localhost:5000/api/notifications?limit=20" | jq
+
+# Only Software Heritage notifications
+curl -s -H "x-api-key: $API_TOKEN" \
+  "http://localhost:5000/api/notifications?origin=swh" | jq
+
+# Fetch a single notification by its storage key
+curl -s -H "x-api-key: $API_TOKEN" \
+  http://localhost:5000/api/notifications/106031488 | jq
 ```
 
 **Supported Notification Types:**

--- a/app/routes/coar_inbox.py
+++ b/app/routes/coar_inbox.py
@@ -1,176 +1,138 @@
 import logging
+import re
 
-from flask import Blueprint, request, jsonify, render_template
+from flask import Blueprint, jsonify, render_template, request
 
-from app.utils.notification_handler import accept_notification, reject_notification, \
-    send_validation_to_viz
+from app.utils.db import get_db
+from app.utils.notification_handler import (
+    accept_notification,
+    reject_notification,
+    send_validation_to_viz,
+)
 
 logger = logging.getLogger(__name__)
 
 coar_inbox_bp = Blueprint("coar_inbox", __name__)
 
-received_notifications = []
+_SWH_ORIGIN = "https://www.softwareheritage.org"
+_OAI_HAL_PREFIX_RE = re.compile(r"^oai:hal:", re.IGNORECASE)
+
+
+def _origin_id(notification: dict) -> str:
+    origin = notification.get("origin") or {}
+    return (origin.get("id") or "").rstrip("/")
+
 
 @coar_inbox_bp.route("/inbox", methods=["POST"])
 def receive_notification():
     """
     COAR Notify inbox.
-    Receives a JSON-LD notification and validates it.
+    Receives a JSON-LD notification, persists it, and dispatches Accept/Reject.
     """
     notification = request.get_json(force=True)
-    notification_types = notification.get('type', [])
+    notification_types = notification.get("type", [])
     logger.info(f"Received COAR notification: {notification_types}")
 
-    # Store the notification for display
-    received_notifications.append(notification)
-
-    if type(notification_types) is list:
-        notification_type = notification_types[0]
+    if isinstance(notification_types, list):
+        notification_type = notification_types[0] if notification_types else None
     else:
         notification_type = notification_types
 
-    notification_origin = notification.get("origin", None)
-    if notification_origin and notification_origin["id"] == "https://www.softwareheritage.org/":
+    # Ignore notifications that originate from Software Heritage to avoid loops.
+    if _origin_id(notification) == _SWH_ORIGIN:
         logger.info("Notification originated from Software Heritage is ignored.")
         return jsonify({
-            "status": "ok",
-            "type": getattr(notification, "type", None),
-            "actor": notification_origin["id"]
+            "status": "ignored",
+            "reason": "Notification from Software Heritage",
+            "actor": _SWH_ORIGIN,
         }), 202
 
+    get_db().store_received_notification(notification)
+
     if notification_type in ("Accept", "Reject"):
-        hal_id_full = notification['object']['object']['id']
-        hal_id = hal_id_full.replace('oai:HAL:', '')
-        software_name = notification['object']['object']['sorg:citation']['name']
+        hal_id_full = notification["object"]["object"]["id"]
+        hal_id = _OAI_HAL_PREFIX_RE.sub("", hal_id_full)
+        software_name = notification["object"]["object"]["sorg:citation"]["name"]
+        accepted = notification_type == "Accept"
 
-        notification_accepted = notification_type == "Accept"
-
-        if notification_accepted:
+        if accepted:
             accept_notification(notification)
         else:
             reject_notification(notification)
 
-        send_validation_to_viz(hal_id, software_name, notification_accepted)
+        send_validation_to_viz(hal_id, software_name, accepted)
 
-    # Respond with the type and actor info
+    actor = notification.get("actor") or {}
     return jsonify({
         "status": "ok",
-        "type": getattr(notification, "type", None),
-        "actor": getattr(notification['actor'], "id", None)
+        "type": notification_type,
+        "actor": actor.get("id"),
     }), 202
+
 
 @coar_inbox_bp.route("/inbox", methods=["GET"])
 def inbox_description():
     """
     COAR Notify inbox description.
-    Returns information about how to send notifications to this inbox.
     """
     return jsonify({
         "title": "COAR Notify Inbox",
-        "description": "This inbox receives COAR-compliant notifications for software mention verification",
+        "description": "Receives COAR-compliant notifications for software mention verification",
         "version": "1.0",
         "endpoints": {
             "POST": {
                 "url": "/inbox",
                 "method": "POST",
                 "content_type": "application/json",
-                "description": "Send a COAR notification to verify or reject software mentions"
+                "description": "Send a COAR notification to verify or reject software mentions",
             },
             "GET": {
                 "url": "/inbox",
                 "method": "GET",
-                "description": "Get this API documentation"
-            }
+                "description": "Get this API documentation",
+            },
         },
         "supported_notification_types": [
             {
                 "type": "Accept",
                 "description": "Accepts a software mention as verified by the author",
-                "purpose": "Marks software as verified in the database"
             },
             {
                 "type": "Reject",
-                "description": "Rejects a software mention",
-                "purpose": "Marks software as not verified by the author"
-            }
+                "description": "Rejects a software mention as not verified by the author",
+            },
         ],
-        "request_format": {
-            "content_type": "application/ld+json",
-            "required_fields": [
-                "type",
-                "actor",
-                "object"
-            ],
-            "example_accept": {
-                "type": "Accept",
-                "actor": {
-                    "type": "Person",
-                    "id": "https://orcid.org/0000-0000-0000-0000"
-                },
-                "object": {
-                    "type": "Offer",
-                    "id": "urn:uuid:12345678-1234-1234-1234-123456789012",
-                    "object": {
-                        "type": "Document",
-                        "id": "oai:HAL:hal-01478788",
-                        "sorg:citation": {
-                            "name": "SoftwareName",
-                            "type": "Software"
-                        }
-                    }
-                }
+        "request_example": {
+            "type": "Accept",
+            "actor": {
+                "type": "Person",
+                "id": "https://orcid.org/0000-0000-0000-0000",
             },
-            "example_reject": {
-                "type": "Reject",
-                "actor": {
-                    "type": "Person",
-                    "id": "https://orcid.org/0000-0000-0000-0000"
-                },
+            "object": {
+                "type": "Offer",
+                "id": "urn:uuid:12345678-1234-1234-1234-123456789012",
                 "object": {
-                    "type": "Offer",
-                    "id": "urn:uuid:12345678-1234-1234-1234-123456789012",
-                    "object": {
-                        "type": "Document",
-                        "id": "oai:HAL:hal-01478788",
-                        "sorg:citation": {
-                            "name": "SoftwareName",
-                            "type": "Software"
-                        }
-                    }
-                }
-            }
-        },
-        "usage_examples": {
-            "curl_accept": "curl -X POST http://localhost:5000/inbox \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"type\": \"Accept\",\n    \"actor\": {\n      \"type\": \"Person\",\n      \"id\": \"https://orcid.org/0000-0000-0000-0000\"\n    },\n    \"object\": {\n      \"type\": \"Offer\",\n      \"id\": \"urn:uuid:12345678-1234-1234-1234-123456789012\",\n      \"object\": {\n        \"type\": \"Document\",\n        \"id\": \"oai:HAL:hal-01478788\",\n        \"sorg:citation\": {\n          \"name\": \"SoftwareName\",\n          \"type\": \"Software\"\n        }\n      }\n    }\n  }'",
-            "curl_reject": "curl -X POST http://localhost:5000/inbox \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"type\": \"Reject\",\n    \"actor\": {\n      \"type\": \"Person\",\n      \"id\": \"https://orcid.org/0000-0000-0000-0000\"\n    },\n    \"object\": {\n      \"type\": \"Offer\",\n      \"id\": \"urn:uuid:12345678-1234-1234-1234-123456789012\",\n      \"object\": {\n        \"type\": \"Document\",\n        \"id\": \"oai:HAL:hal-01478788\",\n        \"sorg:citation\": {\n          \"name\": \"SoftwareName\",\n          \"type\": \"Software\"\n        }\n      }\n    }\n  }'",
-            "python": "import requests\nimport json\n\n# Send Accept notification\naccept_payload = {\n    \"type\": \"Accept\",\n    \"actor\": {\n        \"type\": \"Person\",\n        \"id\": \"https://orcid.org/0000-0000-0000-0000\"\n    },\n    \"object\": {\n        \"type\": \"Offer\",\n        \"id\": \"urn:uuid:12345678-1234-1234-1234-123456789012\",\n        \"object\": {\n            \"type\": \"Document\",\n            \"id\": \"oai:HAL:hal-01478788\",\n            \"sorg:citation\": {\n                \"name\": \"SoftwareName\",\n                \"type\": \"Software\"\n            }\n        }\n    }\n}\n\nresponse = requests.post(\n    \"http://localhost:5000/inbox\",\n    headers={\"Content-Type\": \"application/json\"},\n    json=accept_payload\n)\n\nprint(f\"Status: {response.status_code}\")\nprint(f\"Response: {response.json()}\")"
-        },
-        "responses": {
-            "202": {
-                "description": "Notification accepted and processed",
-                "example": {
-                    "status": "ok",
-                    "type": "Accept",
-                    "actor": "https://orcid.org/0000-0000-0000-0000"
+                    "type": "Document",
+                    "id": "oai:HAL:hal-01478788",
+                    "sorg:citation": {
+                        "name": "SoftwareName",
+                        "type": "Software",
+                    },
                 },
-                "note": "The response contains the notification type and actor ID from the processed notification"
             },
-            "400": {
-                "description": "Invalid request - no JSON data provided or malformed request",
-                "note": "Occurs when the request doesn't contain valid JSON data"
-            }
         },
         "view_notifications": {
             "url": "/notifications",
             "method": "GET",
-            "description": "View all received notifications in a web interface"
-        }
+            "description": "View all received notifications in a web interface",
+        },
     })
 
 
 @coar_inbox_bp.route("/notifications", methods=["GET"])
 def show_notifications():
     """
-    Display all received notifications on a web page.
+    Display all received notifications from the ArangoDB-backed store.
     """
-    return render_template("notifications.html", notifications=received_notifications)
+    records = get_db().list_received_notifications(limit=200)
+    return render_template("notifications.html", records=records)

--- a/app/routes/coar_inbox.py
+++ b/app/routes/coar_inbox.py
@@ -3,6 +3,7 @@ import re
 
 from flask import Blueprint, jsonify, render_template, request
 
+from app.auth import require_api_key
 from app.utils.db import get_db
 from app.utils.notification_handler import (
     accept_notification,
@@ -17,10 +18,33 @@ coar_inbox_bp = Blueprint("coar_inbox", __name__)
 _SWH_ORIGIN = "https://www.softwareheritage.org"
 _OAI_HAL_PREFIX_RE = re.compile(r"^oai:hal:", re.IGNORECASE)
 
+# Recognised origin classifications for stored notifications.
+ORIGIN_SWH = "swh"
+ORIGIN_HAL = "hal"
+ORIGIN_UNKNOWN = "unknown"
+KNOWN_ORIGINS = (ORIGIN_SWH, ORIGIN_HAL)
+
 
 def _origin_id(notification: dict) -> str:
     origin = notification.get("origin") or {}
     return (origin.get("id") or "").rstrip("/")
+
+
+def _classify_origin(notification: dict) -> str:
+    """Classify the sender of an incoming notification as "swh", "hal" or "unknown".
+
+    Matches on substrings of the notification's `origin.id` so it tolerates the
+    various HAL/SWH hostnames in play (e.g. inria.hal.science,
+    inbox-preprod.archives-ouvertes.fr, archive.softwareheritage.org).
+    """
+    origin = _origin_id(notification).lower()
+    if not origin:
+        return ORIGIN_UNKNOWN
+    if "softwareheritage" in origin:
+        return ORIGIN_SWH
+    if "hal" in origin or "archives-ouvertes" in origin:
+        return ORIGIN_HAL
+    return ORIGIN_UNKNOWN
 
 
 @coar_inbox_bp.route("/inbox", methods=["POST"])
@@ -38,16 +62,21 @@ def receive_notification():
     else:
         notification_type = notification_types
 
+    # Persist every received notification (Software Heritage ones included)
+    # before any dispatch decision, so the inbox history is complete. Tag it
+    # with the classified origin (swh/hal/unknown) for later filtering.
+    origin = _classify_origin(notification)
+    get_db().store_received_notification(notification, origin=origin)
+
     # Ignore notifications that originate from Software Heritage to avoid loops.
-    if _origin_id(notification) == _SWH_ORIGIN:
+    # Use the same classification we stored, so dispatch and tagging never disagree.
+    if origin == ORIGIN_SWH:
         logger.info("Notification originated from Software Heritage is ignored.")
         return jsonify({
             "status": "ignored",
             "reason": "Notification from Software Heritage",
-            "actor": _SWH_ORIGIN,
+            "actor": _origin_id(notification) or _SWH_ORIGIN,
         }), 202
-
-    get_db().store_received_notification(notification)
 
     if notification_type in ("Accept", "Reject"):
         hal_id_full = notification["object"]["object"]["id"]
@@ -126,6 +155,21 @@ def inbox_description():
             "method": "GET",
             "description": "View all received notifications in a web interface",
         },
+        "api_notifications": {
+            "list": {
+                "url": "/api/notifications?limit=100&origin=swh",
+                "method": "GET",
+                "auth": "x-api-key header required",
+                "description": "List recent received notifications as JSON, newest first. "
+                               "Optional origin filter: swh or hal.",
+            },
+            "get": {
+                "url": "/api/notifications/<key>",
+                "method": "GET",
+                "auth": "x-api-key header required",
+                "description": "Fetch a single received notification by its storage key",
+            },
+        },
     })
 
 
@@ -136,3 +180,48 @@ def show_notifications():
     """
     records = get_db().list_received_notifications(limit=200)
     return render_template("notifications.html", records=records)
+
+
+@coar_inbox_bp.route("/api/notifications", methods=["GET"])
+@require_api_key
+def api_list_notifications():
+    """
+    Return recently received COAR notifications as JSON, newest first.
+
+    Query params:
+        limit: maximum number of records to return (1-1000, default 100).
+        origin: optional filter, one of "swh" or "hal".
+    """
+    limit = request.args.get("limit", default=100, type=int) or 100
+    limit = max(1, min(limit, 1000))
+
+    origin = request.args.get("origin")
+    if origin is not None:
+        origin = origin.lower()
+        if origin not in KNOWN_ORIGINS:
+            return jsonify({
+                "error": f"Invalid origin '{origin}'. Expected one of: {', '.join(KNOWN_ORIGINS)}.",
+            }), 400
+
+    try:
+        records = get_db().list_received_notifications(limit=limit, origin=origin)
+        return jsonify({"count": len(records), "origin": origin, "notifications": records})
+    except Exception as e:
+        logger.error(f"Failed to list notifications: {e}")
+        return jsonify({"error": "Failed to retrieve notifications"}), 500
+
+
+@coar_inbox_bp.route("/api/notifications/<key>", methods=["GET"])
+@require_api_key
+def api_get_notification(key):
+    """
+    Return a single received notification by its ArangoDB `_key`.
+    """
+    try:
+        record = get_db().get_document_by_key("received_notifications", key)
+        if record:
+            return jsonify(record)
+        return jsonify({"error": "Notification not found"}), 404
+    except Exception as e:
+        logger.error(f"Failed to get notification {key}: {e}")
+        return jsonify({"error": "Failed to retrieve notification"}), 500

--- a/app/templates/notifications.html
+++ b/app/templates/notifications.html
@@ -5,12 +5,16 @@
 </head>
 <body>
     <h1>Received COAR Notifications</h1>
+    {% if not records %}
+        <p><em>No notifications received yet.</em></p>
+    {% endif %}
     <ul>
-        {% for notif in notifications %}
+        {% for record in records %}
             <li>
-                <strong>Type:</strong> {{ notif.type }}<br>
-                <strong>Actor:</strong> {{ notif.actor.id if notif.actor else 'N/A' }}<br>
-                <pre>{{ notif | tojson(indent=2) }}</pre>
+                <strong>Received at:</strong> {{ record.received_at }}<br>
+                <strong>Type:</strong> {{ record.payload.type }}<br>
+                <strong>Actor:</strong> {{ record.payload.actor.id if record.payload.actor else 'N/A' }}<br>
+                <pre>{{ record.payload | tojson(indent=2) }}</pre>
             </li>
         {% endfor %}
     </ul>

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -1,14 +1,14 @@
-import json
 import csv
+import datetime
+import json
 import logging
-import requests
-from typing import Dict, Any, List, Optional, Union
-from pyArango.connection import Connection
-from pyArango.theExceptions import CreationError
-from pyArango.database import Database
+from typing import Any, Dict, List, Optional, Union
+
 from pyArango.collection import Collection
+from pyArango.connection import Connection
+from pyArango.database import Database
+from pyArango.theExceptions import CreationError
 from werkzeug.datastructures import FileStorage
-from flask import current_app
 
 logger = logging.getLogger(__name__)
 
@@ -401,6 +401,7 @@ class DatabaseManager:
                         LET software = DOCUMENT(edge_soft._to)
                         FILTER software.software_name.normalizedForm == @software_name
                         UPDATE software WITH { verification_by_author: @verification } IN software
+                        RETURN NEW
             """
 
             bind_vars = {
@@ -442,6 +443,55 @@ class DatabaseManager:
         except Exception as e:
             logger.error(f"Failed to get collection count for {collection_name}: {e}")
             return 0
+
+    def get_document_by_key(self, collection_name: str, key: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch a single document by `_key` from a named collection.
+        """
+        try:
+            query = f"FOR d IN {collection_name} FILTER d._key == @key RETURN d"
+            result = self.execute_aql_query(
+                query, bind_vars={'key': key}, raw_results=True
+            )
+            docs = list(result)
+            if docs:
+                return docs[0]
+        except Exception as e:
+            logger.error(f"Failed to get document by key {collection_name}/{key}: {e}")
+        return None
+
+    def store_received_notification(self, notification: Dict[str, Any]) -> None:
+        """
+        Persist an incoming COAR notification for later inspection via `/notifications`.
+        """
+        try:
+            collection = self.check_or_create_collection("received_notifications")
+            doc = collection.createDocument({
+                "received_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "payload": notification,
+            })
+            doc.save()
+        except Exception as e:
+            logger.error(f"Failed to persist received notification: {e}")
+
+    def list_received_notifications(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """
+        Return the most recent received notifications, newest first.
+        """
+        try:
+            # Ensure collection exists so the query doesn't fail on a cold DB.
+            self.check_or_create_collection("received_notifications")
+            query = """
+                FOR n IN received_notifications
+                    SORT n.received_at DESC
+                    LIMIT @limit
+                    RETURN n
+            """
+            result = self.execute_aql_query(query, bind_vars={'limit': limit}, raw_results=True)
+            return list(result)
+        except Exception as e:
+            logger.error(f"Failed to list received notifications: {e}")
+            return []
 
     def get_document_by_id(self, id: str) -> Optional[Dict[str, Any]]:
         """
@@ -489,24 +539,24 @@ class DatabaseManager:
         """
         try:
             query = """
-                LET doc = (
+                LET matching_docs = (
                     FOR d IN documents
                         FILTER d.file_hal_id == @document_id
                         RETURN d
                 )
 
                 LET software_to_delete = (
-                    FOR d IN documents
-                        FILTER d.file_hal_id == @document_id
+                    FOR d IN matching_docs
                         FOR edge IN edge_doc_to_software
                             FILTER edge._from == d._id
                             RETURN DOCUMENT(edge._to)
                 )
 
                 LET delete_edges = (
-                    FOR edge IN edge_doc_to_software
-                        FILTER edge._from IN DOCUMENT(doc)._id
-                        REMOVE edge IN edge_doc_to_software
+                    FOR d IN matching_docs
+                        FOR edge IN edge_doc_to_software
+                            FILTER edge._from == d._id
+                            REMOVE edge IN edge_doc_to_software
                 )
 
                 LET delete_software = (
@@ -515,8 +565,7 @@ class DatabaseManager:
                 )
 
                 LET delete_doc = (
-                    FOR d IN documents
-                        FILTER d.file_hal_id == @document_id
+                    FOR d IN matching_docs
                         REMOVE d IN documents
                 )
 

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -460,34 +460,51 @@ class DatabaseManager:
             logger.error(f"Failed to get document by key {collection_name}/{key}: {e}")
         return None
 
-    def store_received_notification(self, notification: Dict[str, Any]) -> None:
+    def store_received_notification(
+        self, notification: Dict[str, Any], origin: Optional[str] = None
+    ) -> None:
         """
         Persist an incoming COAR notification for later inspection via `/notifications`.
+
+        `origin` is our derived classification of the sender (e.g. "swh", "hal",
+        "unknown"), stored alongside the verbatim payload so it can be filtered on.
         """
         try:
             collection = self.check_or_create_collection("received_notifications")
             doc = collection.createDocument({
-                "received_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "received_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "origin": origin,
                 "payload": notification,
             })
             doc.save()
         except Exception as e:
             logger.error(f"Failed to persist received notification: {e}")
 
-    def list_received_notifications(self, limit: int = 100) -> List[Dict[str, Any]]:
+    def list_received_notifications(
+        self, limit: int = 100, origin: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
         """
         Return the most recent received notifications, newest first.
+
+        If `origin` is given, only notifications classified with that origin
+        (e.g. "swh" or "hal") are returned.
         """
         try:
             # Ensure collection exists so the query doesn't fail on a cold DB.
             self.check_or_create_collection("received_notifications")
-            query = """
+            bind_vars: Dict[str, Any] = {'limit': limit}
+            origin_filter = ""
+            if origin:
+                origin_filter = "FILTER n.origin == @origin"
+                bind_vars['origin'] = origin
+            query = f"""
                 FOR n IN received_notifications
+                    {origin_filter}
                     SORT n.received_at DESC
                     LIMIT @limit
                     RETURN n
             """
-            result = self.execute_aql_query(query, bind_vars={'limit': limit}, raw_results=True)
+            result = self.execute_aql_query(query, bind_vars=bind_vars, raw_results=True)
             return list(result)
         except Exception as e:
             logger.error(f"Failed to list received notifications: {e}")


### PR DESCRIPTION
Replace the in-process notification list with a received_notifications collection so the inbox survives restarts and is shared across gunicorn workers. Adds store_received_notification / list_received_notifications / get_document_by_key, returns NEW from the verification update so callers see real success counts, and fixes the delete_document_by_id AQL to reuse a single matching_docs binding. /notifications now reads from the DB.